### PR TITLE
Fix incorrect boundary check in getPrevExpansionCharacter

### DIFF
--- a/com/mcleodgaming/ssf2/Main.as
+++ b/com/mcleodgaming/ssf2/Main.as
@@ -1146,7 +1146,7 @@
       public static function getPrevExpansionCharacter(param1:Number) : Number
       {
          param1 = param1 - 1;
-         if(param1 < m_expansionData.length)
+         if(param1 < 0)
          {
             param1 = m_expansionData.length - 1;
          }


### PR DESCRIPTION
## Summary
- correct boundary check for negative index when cycling through expansion characters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840740e506c8332b9c0d50a50579f86